### PR TITLE
Fixes to tabs PR

### DIFF
--- a/app/src/components/header.js
+++ b/app/src/components/header.js
@@ -1,7 +1,7 @@
 import { Link } from "gatsby"
 import PropTypes from "prop-types"
-import React, {useState} from "react"
-import './header.scss';
+import React, { useEffect } from "react"
+import './header.scss'
 
 function getSelectedTab() {
   if (window.location.pathname.match(/^\/about/)) {
@@ -20,13 +20,17 @@ function getSelectedTab() {
 }
 
 const Header = ({ siteTitle }) => {
-  const selectedTab = getSelectedTab()
+  let selectedTab = ''
   const getTabClass = tab => tab === selectedTab ? 'selected' : ''
+
+  useEffect(() => {
+    selectedTab = getSelectedTab()
+  })
 
   return (
     <header>
       <div>
-        <h1 style={{ margin: 0 }}>
+        <h1>
           <Link to="/">{siteTitle}</Link>
         </h1>
 


### PR DESCRIPTION
1. Remove unneeded style and semicolon
1. Move client code to be executed within `useEffect` so it doesn't break SSR