### PR TITLE
Add list options

### DIFF
--- a/app/src/components/listOptions.js
+++ b/app/src/components/listOptions.js
@@ -1,0 +1,24 @@
+import PropTypes from "prop-types"
+import React from "react"
+import { SelectableOption } from "./selectableOption"
+
+export function ListOptions({ sortType, setSortType, displayType, setDisplayType }) {
+  return <div className="list-options">
+    <span>
+      מיין לפי
+      <SelectableOption selected={sortType === 'frequency'} onSelect={() => setSortType('frequency')}>שכיחות</SelectableOption>
+      <SelectableOption selected={sortType === 'alphabet'} onSelect={() => setSortType('alphabet')}>אלף-בית</SelectableOption>
+    </span>
+    <span>
+      הצג בתור
+      <SelectableOption selected={displayType === 'list'} onSelect={() => setDisplayType('list')}>רשימה</SelectableOption>
+      <SelectableOption selected={displayType === 'cloud'} onSelect={() => setDisplayType('cloud')}>ענן</SelectableOption>
+    </span>
+  </div>
+}
+ListOptions.propTypes = {
+  sortType: PropTypes.oneOf(['frequency', 'alphabet']).isRequired,
+  setSortType: PropTypes.func.isRequired,
+  displayType: PropTypes.oneOf(['list', 'cloud']).isRequired,
+  setDisplayType: PropTypes.func.isRequired,
+}

--- a/app/src/components/selectableOption.js
+++ b/app/src/components/selectableOption.js
@@ -1,0 +1,11 @@
+import PropTypes from "prop-types"
+import React from "react"
+
+export function SelectableOption({ selected, children, onSelect }) {
+  return <span className={`option ${selected ? 'selected' : ''}`} onClick={onSelect}>{children}</span>
+}
+
+SelectableOption.propTypes = {
+  selected: PropTypes.bool.isRequired,
+  onSelect: PropTypes.func.isRequired,
+}

--- a/app/src/hooks/useLocalStorage.js
+++ b/app/src/hooks/useLocalStorage.js
@@ -1,0 +1,26 @@
+// https://usehooks.com/useLocalStorage/
+import { useState } from "react"
+
+export function useLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      console.log(error)
+      return initialValue
+    }
+  })
+
+  const setValue = value => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
+      window.localStorage.setItem(key, JSON.stringify(valueToStore))
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  return [storedValue, setValue]
+}

--- a/app/src/templates/characters.js
+++ b/app/src/templates/characters.js
@@ -1,31 +1,39 @@
 import React from "react"
 import Layout from "../components/layout"
 import { Link } from "gatsby"
+import { ListOptions } from "../components/listOptions"
+import { useLocalStorage } from "../hooks/useLocalStorage"
 
-export default function Characters(props) {
-  const { characters, charactersMap } = props.pageContext
-  characters.sort((c1, c2)=> {
-    const delta = charactersMap[c2].length - charactersMap[c1].length
-    if (delta != 0) return delta
-    return c2 - c1
-  })
+export default function Characters({ pageContext: { characters, charactersMap } }) {
+  const [sortType, setSortType] = useLocalStorage('sortType', 'frequency')
+  const [displayType, setDisplayType] = useLocalStorage('displayType', 'cloud')
+
+  if (sortType === 'frequency') {
+    characters.sort((c1, c2) => {
+      const delta = charactersMap[c2].length - charactersMap[c1].length
+      return delta !== 0 ? delta : c2 - c1
+    })
+  } else {
+    characters.sort()
+  }
 
   return (
     <Layout domain="characters">
-      <h1>{characters.length} דמויות</h1>
-      <ul className="characters">
-        {characters.map(c => {
-          return (
-            <div key={c}>
-              <li className="character">
-                <Link to={`/characters/${c}`}>
-                  {c} ({charactersMap[c].length})
-                </Link>
-              </li>
-              <br />
-            </div>
-          )
-        })}
+      <div className="title">
+        <h1>{characters.length} דמויות</h1>
+        <ListOptions sortType={sortType} setSortType={setSortType} displayType={displayType} setDisplayType={setDisplayType} />
+      </div>
+      <ul className={`list characters ${displayType}`}>
+        {characters.map(c => (
+          <div key={c}>
+            <li className="character">
+              <Link to={`/characters/${c}`}>
+                {c} ({charactersMap[c].length})
+              </Link>
+            </li>
+            <br />
+          </div>
+        ))}
       </ul>
     </Layout>
   )

--- a/app/src/templates/sketch.css
+++ b/app/src/templates/sketch.css
@@ -1,32 +1,70 @@
-ul.characters {
+ul.list {
   list-style-type: none;
  }
 
-ul.tags {
-  list-style-type: none;
+ul.list > div {
+  margin-block-end: 3px;
+}
+
+ul.list.cloud > div {
+  display: inline flow-root list-item;
+}
+
+ul.list li {
+  display: inline;
+  margin-left: 7px;
+  margin-bottom: 3px;
+  border-radius: 25px;
+  background: #73AD21;
+  padding: 1px 7px;
 }
 
 li.character {
-  display: inline;
-  margin-left: 1em;
-  border-radius: 25px;
   background: #73AD21;
-  padding-left: 0.5em;
 }
 
 li.character:hover {
   background: lightgreen;
 }
 
-
 li.tag {
-  display: inline;
-  margin-left: 1em;
-  border-radius: 25px;
   background: red;
-  padding-left: 0.5em;
 }
 
 li.tag:hover {
   background: lightcoral;
+}
+
+.title {
+  display: flex;
+  justify-content: space-between;
+}
+
+.list-options {
+  margin-block-end: 10px;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.list-options > * {
+  margin-bottom: 10px;
+}
+
+.option {
+  margin-inline-start: 5px;
+  border: 1px solid lightslategray;
+  border-radius: 23px;
+  padding: 1px 10px;
+  cursor: pointer;
+}
+
+.option.selected {
+  color: white;
+  background-color: rebeccapurple;
+}
+
+.option:last-of-type {
+  margin-inline-end: 30px;
 }

--- a/app/src/templates/tags.js
+++ b/app/src/templates/tags.js
@@ -1,32 +1,39 @@
 import React from "react"
 import Layout from "../components/layout"
 import {Link} from "gatsby"
+import { ListOptions } from "../components/listOptions"
+import { useLocalStorage } from "../hooks/useLocalStorage"
 
-export default function Tags( props ) {  
-  const {tags, tagsMap} = props.pageContext
-  tags.sort((t1, t2)=> {
-    const delta = tagsMap[t2].length - tagsMap[t1].length
-    if (delta != 0) return delta
-    return t2 - t1
-  })
+export default function Tags({ pageContext: { tags, tagsMap } }) {
+  const [sortType, setSortType] = useLocalStorage('sortType', 'frequency')
+  const [displayType, setDisplayType] = useLocalStorage('displayType', 'cloud')
+
+  if (sortType === 'frequency') {
+    tags.sort((t1, t2) => {
+      const delta = tagsMap[t2].length - tagsMap[t1].length
+      return delta !== 0 ? delta : t2 - t1
+    })
+  } else {
+    tags.sort()
+  }
   return (
     <Layout domain="tags">
-      <h1>{tags.length} תגיות</h1>
-      <ul className='tags'>
-        {tags.map(t => {
-          return (
-            <div key={t}>
-            <li className='tag'>
-              <Link to={`/tags/${t}`}>
-                {t} ({tagsMap[t].length})
-              </Link>
-            </li>
-            <br/>
-            </div>
-          )
-        })}
+      <div className="title">
+        <h1>{tags.length} תגיות</h1>
+        <ListOptions sortType={sortType} setSortType={setSortType} displayType={displayType} setDisplayType={setDisplayType} />
+      </div>
+      <ul className={`list tags ${displayType}`}>
+        {tags.map(t => (
+          <div key={t}>
+          <li className='tag'>
+            <Link to={`/tags/${t}`}>
+              {t} ({tagsMap[t].length})
+            </Link>
+          </li>
+          <br/>
+          </div>
+        ))}
       </ul>
-      
     </Layout>
   )
 }


### PR DESCRIPTION
Enable setting sort type (frequency/alphabet) and display type (list/cloud) for tags and charachter.

Settings are stored in `localStorage` and are shared between tags and characters.